### PR TITLE
Add node-pre-gyp to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "typescript": "^4.1.3"
   },
   "dependencies": {
+    "node-pre-gyp": "^0.17.0",
     "wrtc": "^0.4.7"
   }
 }


### PR DESCRIPTION
This will fix this error while installing:
```
ubuntu@ubuntu:~$ npm i tgcalls
npm ERR! code 1
npm ERR! path /home/ubuntu/gjt/node_modules/wrtc
npm ERR! command failed
npm ERR! command sh -c node scripts/download-prebuilt.js
npm ERR! /bin/sh: 1: node-pre-gyp: not found

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/ubuntu/.npm/_logs/2021-04-25T07_14_20_551Z-debug.log
```
 and will no longer require installing `node-pre-gyp` manually.