### PR TITLE
Remove listeners of the previous readable

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -11,8 +11,8 @@ export class Stream extends EventEmitter {
     private _stopped = false;
     private _finishedLoading = false;
     private _emittedAlmostFinished = false;
-    private dataListener?: (data:any)=>void;
-    private endListener?: ()=>void;
+    private dataListener?: (data: any) => void;
+    private endListener?: () => void;
 
     constructor(
         readable?: Readable,
@@ -87,25 +87,25 @@ export class Stream extends EventEmitter {
     createTrack() {
         return this.audioSource.createTrack();
     }
-    
+
     private getDataListener() {
         if (this.dataListener) {
             return this.dataListener;
         }
 
         this.dataListener = ((data: any) => {
-            this.cache = Buffer.concat([this.cache, data])
+            this.cache = Buffer.concat([this.cache, data]);
         }).bind(this);
         return this.dataListener;
     }
 
     private getEndListener() {
         if (this.endListener) {
-            return this.endListener
+            return this.endListener;
         }
 
-        this.endListener = (() =>{
-        this._finishedLoading = true;
+        this.endListener = (() => {
+            this._finishedLoading = true;
         }).bind(this);
         return this.endListener;
     }
@@ -115,9 +115,15 @@ export class Stream extends EventEmitter {
             return;
         }
 
-        const byteLength = ((this.sampleRate * this.bitsPerSample) / 8 / 100) * this.channelCount;
+        const byteLength =
+            ((this.sampleRate * this.bitsPerSample) / 8 / 100) *
+            this.channelCount;
 
-        if (!this._paused && !this._finished && (this.cache.length >= byteLength || this._finishedLoading)) {
+        if (
+            !this._paused &&
+            !this._finished &&
+            (this.cache.length >= byteLength || this._finishedLoading)
+        ) {
             const buffer = this.cache.slice(0, byteLength);
             const samples = new Int16Array(new Uint8Array(buffer).buffer);
 
@@ -139,7 +145,8 @@ export class Stream extends EventEmitter {
         if (!this._finished && this._finishedLoading) {
             if (
                 !this._emittedAlmostFinished &&
-                this.cache.length < byteLength + this.almostFinishedTrigger * this.sampleRate
+                this.cache.length <
+                    byteLength + this.almostFinishedTrigger * this.sampleRate
             ) {
                 this._emittedAlmostFinished = true;
                 this.emit('almost-finished');

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -86,11 +86,13 @@ export class Stream extends EventEmitter {
         return this.audioSource.createTrack();
     }
 
-    dataListener = ((data: any) => {
+    private dataListener = ((data: any) => {
         this.cache = Buffer.concat([this.cache, data]);
     }).bind(this);
 
-    endListener = (() => (this._finishedLoading = true)).bind(this);
+    private endListener = (() => {
+        this._finishedLoading = true;
+    }).bind(this);
 
     private processData() {
         if (this._stopped) {


### PR DESCRIPTION
There is a serious bug in the `Stream` class' `setReadable` method that let multiple unfinished readables stream together in the same time, it is caused because the listeners from the previous readables aren't removed in the `setReadable` method. This PR attempts to fix that bug by removing the listeners of the current readable before adding the listeners to another one.
