### PR TITLE
Fix prepare script not working on Windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "npm run prepare",
     "test": "tsc --noEmit",
-    "prepare": "rm -rf lib/ && tsc",
+    "prepare": "tsc",
     "preversion": "npm run test",
     "docs": "typedoc src/index.ts"
   },


### PR DESCRIPTION
- Fix the prepare script not working on Windows while `npm install`ing because the rm -rf is not a valid Windows command.