### PR TITLE
Fix `StreamOptions`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,37 @@
 # tgcallsjs
 
+[![npm](https://img.shields.io/npm/v/tgcalls)][npm]
+
+## Example
+
+```ts
+import { createReadStream } from 'fs';
+import { TGCalls, Stream } from 'tgcalls';
+
+const tgcalls = new TGCalls();
+
+tgcalls.joinVoiceCall = payload => {
+    // Somehow join voice call and get transport
+
+    return transport;
+};
+
+const stream = new Stream(createReadStream('song.raw'));
+
+// See the docs for more event types
+// https://tgcallsjs.github.io/tgcalls/classes/stream.html#on
+stream.on('finish', () => {
+    console.log('Song finished');
+});
+
+tgcalls.start(stream.createTrack());
+```
+
 ## Credits
 
 Big thanks to [@evgeny-nadymov] for allowing us to use their code from [telegram-react], and [@Laky-64] for helping write this library!
 
+[npm]: https://www.npmjs.com/package/tgcalls
 [@evgeny-nadymov]: https://github.com/evgeny-nadymov/
 [telegram-react]: https://github.com/evgeny-nadymov/telegram-react/
 [@laky-64]: https://github.com/Laky-64/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tgcallsjs
 
-[![npm](https://img.shields.io/npm/v/tgcalls)][npm]
+[![npm](https://img.shields.io/npm/v/tgcalls)](https://npmjs.com/package/tgcalls) [![Mentioned in Awesome Telegram Calls](https://awesome.re/mentioned-badge.svg)](https://github.com/tgcalls/awesome-tgcalls)
 
 ## Example
 
@@ -26,6 +26,10 @@ stream.on('finish', () => {
 
 tgcalls.start(stream.createTrack());
 ```
+
+## Related projects
+
+- [gram-tgcalls](https://github.com/tgcallsjs/gram-tgcalls): connects tgcallsjs with [GramJS](https://github.com/gram-js/gramjs) and makes using this lib super easy.
 
 ## Credits
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # tgcallsjs
 
-[![npm](https://img.shields.io/npm/v/tgcalls)](https://npmjs.com/package/tgcalls) [![Mentioned in Awesome Telegram Calls](https://awesome.re/mentioned-badge.svg)](https://github.com/tgcalls/awesome-tgcalls)
+[![npm](https://img.shields.io/npm/v/tgcalls)][npm] [![Mentioned in Awesome Telegram Calls](https://awesome.re/mentioned-badge.svg)][awesome]
 
 ## Example
 
@@ -32,17 +32,17 @@ tgcalls.start(audioStream.createTrack(), videoStream.createTrack());
 
 Video:
 
-- Format: yuv420p
-- Resolution: min 640x360, max 1280x720
-- FPS: 24 or what you provided in `StreamOptions`
+-   Format: `yuv420p`
+-   Resolution: min 640x360, max 1280x720
+-   FPS: 24 or what you provided in `StreamOptions`
 
 Audio:
 
-- Format: s16le
-- Channels: 2
-- Bitrate: 65K or what you provided in `StreamOptions`
+-   Format: `s16le`
+-   Channels: 2
+-   Bitrate: 65K or what you provided in `StreamOptions`
 
-### Conversion with Ffmpeg
+### Conversion with FFmpeg
 
 Video:
 
@@ -60,21 +60,24 @@ Or both from a video input:
 
 ```bash
 ffmpeg -i [input] \
- -f s16le -ac 1 -ar 65K [audio_output] \
- -f yuv420p -vf scale=640:-1 -r 24 [video_output]
+    -f s16le -ac 1 -ar 65K [audio_output] \
+    -f yuv420p -vf scale=640:-1 -r 24 [video_output]
 ```
 
 Note: these examples are using default values of configurable options.
 
 ## Related projects
 
-- [gram-tgcalls](https://github.com/tgcallsjs/gram-tgcalls): connects tgcallsjs with [GramJS](https://github.com/gram-js/gramjs) and makes using this lib super easy.
+-   [gram-tgcalls]: connects tgcallsjs with [GramJS] and makes using this library super easy.
 
 ## Credits
 
 Big thanks to [@evgeny-nadymov] for allowing us to use their code from [telegram-react], and [@Laky-64] for helping write this library!
 
 [npm]: https://www.npmjs.com/package/tgcalls
+[awesome]: https://github.com/tgcalls/awesome-tgcalls
+[gram-tgcalls]: https://github.com/tgcallsjs/gram-tgcalls
+[gramjs]: https://github.com/gram-js/gramjs
 [@evgeny-nadymov]: https://github.com/evgeny-nadymov/
 [telegram-react]: https://github.com/evgeny-nadymov/telegram-react/
 [@laky-64]: https://github.com/Laky-64/

--- a/README.md
+++ b/README.md
@@ -27,6 +27,44 @@ stream.on('finish', () => {
 tgcalls.start(stream.createTrack());
 ```
 
+## Required media properties
+
+Video:
+
+- Format: yuv420p
+- Resolution: min 640x360, max 1280x720
+- FPS: 24 or what you provided in `StreamOptions`
+
+Audio:
+
+- Format: s16le
+- Channels: 2
+- Bitrate: 65K or what you provided in `StreamOptions`
+
+### Conversion with Ffmpeg
+
+Video:
+
+```bash
+ffmpeg -i [input] -f yuv420p -vf scale=640:-1 -r 24 [output]
+```
+
+Audio:
+
+```bash
+ffmpeg -i [input] -f s16le -ac 1 -ar 65K [output]
+```
+
+Or both from a video input:
+
+```bash
+ffmpeg -i [input] \
+ -f s16le -ac 1 -ar 65K [audio_output] \
+ -f yuv420p -vf scale=640:-1 -r 24 [video_output]
+```
+
+Note: these examples are using default values of configurable options.
+
 ## Related projects
 
 - [gram-tgcalls](https://github.com/tgcallsjs/gram-tgcalls): connects tgcallsjs with [GramJS](https://github.com/gram-js/gramjs) and makes using this lib super easy.

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ tgcalls.joinVoiceCall = payload => {
 };
 
 const audioStream = new Stream(createReadStream('audio.raw'));
-const videoStream = new Stream(createReadStream('video.raw'));
+const videoStream = new Stream(createReadStream('video.raw'), { video: true });
 
 // See the docs for more event types
 // https://tgcallsjs.github.io/tgcalls/classes/stream.html#on

--- a/README.md
+++ b/README.md
@@ -16,15 +16,16 @@ tgcalls.joinVoiceCall = payload => {
     return transport;
 };
 
-const stream = new Stream(createReadStream('song.raw'));
+const audioStream = new Stream(createReadStream('audio.raw'));
+const videoStream = new Stream(createReadStream('video.raw'));
 
 // See the docs for more event types
 // https://tgcallsjs.github.io/tgcalls/classes/stream.html#on
-stream.on('finish', () => {
-    console.log('Song finished');
+audioStream.on('finish', () => {
+    console.log('Audio finished streaming');
 });
 
-tgcalls.start(stream.createTrack());
+tgcalls.start(audioStream.createTrack(), videoStream.createTrack());
 ```
 
 ## Required media properties

--- a/src/stream.ts
+++ b/src/stream.ts
@@ -26,26 +26,26 @@ export class Stream extends EventEmitter {
     public width: number = 640;
     public height: number = 360;
     readonly framerate: number = 24;
-    readonly bitsPerSample: number;
-    readonly sampleRate: number;
-    readonly channelCount: number;
-    private almostFinishedTrigger: number;
+    readonly bitsPerSample: number = 16;
+    readonly sampleRate: number = 65000;
+    readonly channelCount: number = 1;
+    private almostFinishedTrigger: number = 20;
 
     constructor(readable?: Readable, options?: StreamOptions) {
         super();
 
-        if (typeof options?.video === 'boolean') {
-            this.video = options?.video ?? true;
-        } else if (options?.video) {
-            this.width = options.video.width ?? this.width;
-            this.height = options.video.height ?? this.height;
-            this.framerate = options.video.framerate ?? this.framerate;
-        }
+        this.video = options?.video ?? this.video;
 
-        this.bitsPerSample = options?.audio?.bitsPerSample ?? 16;
-        this.sampleRate = options?.audio?.sampleRate ?? 65000;
-        this.channelCount = options?.audio?.channelCount ?? 1;
-        this.almostFinishedTrigger = options?.almostFinishedTrigger ?? 20;
+        this.width = options?.width ?? this.width;
+        this.height = options?.height ?? this.height;
+        this.framerate = options?.framerate ?? this.framerate;
+
+        this.bitsPerSample = options?.bitsPerSample ?? this.bitsPerSample;
+        this.sampleRate = options?.sampleRate ?? this.sampleRate;
+        this.channelCount = options?.channelCount ?? this.channelCount;
+
+        this.almostFinishedTrigger =
+            options?.almostFinishedTrigger ?? this.almostFinishedTrigger;
 
         this.audioSource = new nonstandard.RTCAudioSource();
         this.videoSource = new nonstandard.RTCVideoSource();

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,20 +1,20 @@
-export interface StreamVideoOptions {
+export interface VideoStreamOptions {
     width?: number;
     height?: number;
     framerate?: number;
 }
 
-export interface StreamAudioOptions {
+export interface AudioStreamOptions {
     bitsPerSample?: number;
     sampleRate?: number;
     channelCount?: number;
 }
 
-export interface StreamOptions {
-    audio?: StreamAudioOptions;
-    video?: StreamVideoOptions | true;
-    almostFinishedTrigger?: number;
-}
+export type StreamOptions = VideoStreamOptions &
+    AudioStreamOptions & {
+        video?: boolean;
+        almostFinishedTrigger?: number;
+    };
 
 export interface Fingerprint {
     hash: string;


### PR DESCRIPTION
- Rename `StreamVideoOptions` to `VideoStreamOptions`.
- Rename `StreamAudioOptions` to `AudioStreamOptions`.
- Make `StreamOption` a merge of audio and stream options.
- Add the boolean type `video` to `StreamOptions`.
- Set default fallback of `video` to `false`.
- Fix the example in the README.