### PR TITLE
Set `_stopped` to `true` before calling `finish`

### DIFF
--- a/src/stream.ts
+++ b/src/stream.ts
@@ -102,8 +102,8 @@ export class Stream extends EventEmitter {
     }
 
     stop() {
-        this.finish();
         this._stopped = true;
+        this.finish();
     }
 
     get stopped() {


### PR DESCRIPTION
- To let the finish listener know if it is stopped.